### PR TITLE
Fix AntProject#java for JRuby

### DIFF
--- a/lib/ant_project.rb
+++ b/lib/ant_project.rb
@@ -90,8 +90,8 @@ module Antwrap
       
     end
     
-    def java(*args)
-      method_missing(:java, *args)
+    def java(*args, &block)
+      method_missing(:java, *args, &block)
     end
 
     def method_missing(sym, *args)


### PR DESCRIPTION
When calling the AntProject#java task from JRuby, #method_missing is not invoked due to all Objects implicitly getting a #java method on the JRuby platform.

This patch explicitly declares the #java method on AntProject so as to ensure that calls to #java get routed to #method_missing in JRuby -- as one would expect.

This was discovered during the development of buildr-mirah: http://github.com/thomaslee/buildr-mirah -- happy to reproduce this in isolation if it's helpful.
