### PR TITLE
Use java_import to silence deprecation warnings

### DIFF
--- a/lib/java_adapter.rb
+++ b/lib/java_adapter.rb
@@ -45,7 +45,7 @@ module Antwrap
     
     private    
     def JavaAdapter.import_using_jruby(name)
-      include_class(name) 
+      java_import(name) 
       return remove_const(name.scan(/[_a-zA-Z0-9$]+/).last)
     end
   end


### PR DESCRIPTION
Gets rid of a number of deprecation warnings every time antwrap is used in jruby
