### PR TITLE
Use newer Hoe version, update URLs in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 = Antwrap
     by Caleb Powell
-    http://rubyforge.org/projects/antwrap/
+    https://github.com/atoulme/Antwrap
 
 == DESCRIPTION:
 
@@ -9,12 +9,12 @@
 == FEATURES/PROBLEMS:
 
 	Antwrap runs on the native Ruby interpreter via the RJB (Ruby Java Bridge gem) and on the JRuby interpreter. Antwrap is compatible with Ant versions 1.5.4, 
-	1.6.5 and 1.7.0. For more information, 	see the Project Info (http://rubyforge.org/projects/antwrap/) page. 
+	1.6.5 and 1.7.0. For more information, 	see the Project Info (https://github.com/atoulme/Antwrap) page. 
 	 
 == SYNOPSIS:
 
-	Antwrap is a Ruby library that can be used to invoke Ant tasks. It is being used in the Buildr (http://incubator.apache.org/buildr/) project to execute 
-	Ant (http://ant.apache.org/) tasks in a Java project. If you are tired of fighting with Ant or Maven XML files in your Java project, take some time to 
+	Antwrap is a Ruby library that can be used to invoke Ant tasks. It is being used in the Buildr (https://buildr.apache.org/) project to execute 
+	Ant (https://ant.apache.org/) tasks in a Java project. If you are tired of fighting with Ant or Maven XML files in your Java project, take some time to 
 	check out Buildr!
 
 == USAGE:

--- a/README.txt
+++ b/README.txt
@@ -117,7 +117,7 @@
 == REQUIREMENTS:
 
 	rjb >= 1.0.3 (on MRI Ruby)
-	hoe >= 1.3.0
+	hoe >= 3.14.2
 
 == INSTALL:
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,10 +19,10 @@ require 'rake/testtask'
 
 def apply_default_hoe_properties(hoe)
   hoe.remote_rdoc_dir = ''
-  hoe.rubyforge_name = 'antwrap'
+  hoe.group_name = 'antwrap'
   hoe.author = 'Caleb Powell'
   hoe.email = 'caleb.powell@gmail.com'
-  hoe.urls = ['http://rubyforge.org/projects/antwrap/']
+  hoe.urls = { 'home' => 'http://rubyforge.org/projects/antwrap/' }
   hoe.summary = 'A Ruby module that wraps the Apache Ant build tool. Antwrap can be used to invoke Ant Tasks from a Ruby or a JRuby script.'
   hoe.description = hoe.paragraphs_of('README.txt', 2..5).join("\n\n")
   hoe.changes = hoe.paragraphs_of('History.txt', 0..1).join("\n\n")
@@ -33,15 +33,15 @@ def apply_default_hoe_properties(hoe)
 end
 
 #builds the MRI Gem
-Hoe.spec('atoulme-Antwrap') do |hoe|
-  apply_default_hoe_properties hoe
-  hoe.extra_deps << ["rjb", ">= 1.0.3"]
+Hoe.spec('atoulme-Antwrap') do
+  apply_default_hoe_properties(self)
+  extra_deps << ["rjb", ">= 1.0.3"]
 end
 
 #builds the JRuby Gem
-Hoe.spec('atoulme-Antwrap') do |hoe|
-  apply_default_hoe_properties hoe
-  hoe.spec_extras = {:platform => 'java'}
+Hoe.spec('atoulme-Antwrap') do
+  apply_default_hoe_properties(self)
+  spec_extras[:platform] = 'java'
 end
 
 Rake::TestTask.new('test') do |t|


### PR DESCRIPTION
Hi!

This PR updates the Hoe usage to support newest release of Hoe.

  - remove references to RubyForge
  - use the Hash form for `urls`, pointing out this repo
  - update `hoe` version needed in README
  - update URLs to projects in README